### PR TITLE
feat: implement initial MCP security tools server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# sec-skills-mcp
+
+An MCP (Model Context Protocol) server written in Go that provides security tools and skills for penetration testers. It exposes capabilities such as port scanning via `nmap` and DNS enumeration to AI assistants.
+
+> **Important**: Only use these tools against systems you own or have explicit written authorization to test. Unauthorized scanning is illegal.
+
+## Prerequisites
+
+- Go 1.22 or later
+- `nmap` installed and available in `PATH` (for the `nmap_scan` tool)
+
+## Installation
+
+### Build from source
+
+```bash
+git clone https://github.com/mycroft/sec-skills-mcp.git
+cd sec-skills-mcp
+go build -o sec-skills-mcp .
+```
+
+### Install via `go install`
+
+```bash
+go install github.com/mycroft/sec-skills-mcp@latest
+```
+
+## Configuration
+
+The server communicates over stdio using the MCP protocol. Configure it in your MCP client (e.g. Claude Desktop) by adding an entry like:
+
+```json
+{
+  "mcpServers": {
+    "sec-skills-mcp": {
+      "command": "/path/to/sec-skills-mcp"
+    }
+  }
+}
+```
+
+## Tools
+
+### `nmap_scan`
+
+Scan ports on a target host using `nmap`.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `target`  | Yes      | Target IP address or hostname |
+| `ports`   | No       | Port range (e.g. `80`, `1-1024`, `80,443,8080`). Scans common ports if omitted. |
+
+**Example prompt**: "Scan ports 80 and 443 on 192.168.1.1"
+
+### `dns_lookup`
+
+Perform DNS lookups for a domain, returning A, AAAA, MX, NS, and TXT records.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `domain`  | Yes      | Domain name to query (e.g. `example.com`) |
+
+**Example prompt**: "Look up DNS records for example.com"
+
+## Development
+
+```bash
+# Install dependencies
+go mod tidy
+
+# Build
+go build -o sec-skills-mcp .
+
+# Run tests
+go test ./...
+
+# Run tests with verbose output
+go test -v ./...
+```
+
+## Responsible Use
+
+This tool is intended for authorized security testing only. Users are solely responsible for obtaining proper written authorization before scanning any target. Unauthorized use may violate laws including the Computer Fraud and Abuse Act (CFAA) and similar regulations in other jurisdictions.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/mycroft/sec-skills-mcp
+
+go 1.22
+
+require github.com/mark3labs/mcp-go v0.20.0

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -1,0 +1,22 @@
+package exec
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+// Run executes the named command with args and returns the combined stdout+stderr output.
+func Run(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+// LookPath checks whether a binary is available in the system PATH.
+func LookPath(name string) error {
+	_, err := exec.LookPath(name)
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"log"
+
+	"github.com/mark3labs/mcp-go/server"
+
+	mcpserver "github.com/mycroft/sec-skills-mcp/server"
+)
+
+func main() {
+	s := mcpserver.New()
+	if err := server.ServeStdio(s); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/mycroft/sec-skills-mcp/tools/dns"
+	"github.com/mycroft/sec-skills-mcp/tools/nmap"
+)
+
+// New creates and returns a configured MCP server with all security tools registered.
+func New() *server.MCPServer {
+	s := server.NewMCPServer(
+		"sec-skills-mcp",
+		"1.0.0",
+		server.WithToolCapabilities(true),
+	)
+
+	s.AddTool(mcp.NewTool("nmap_scan",
+		mcp.WithDescription("Scan ports on a target host using nmap. Only use against hosts you are authorized to scan."),
+		mcp.WithString("target",
+			mcp.Required(),
+			mcp.Description("Target IP address or hostname to scan"),
+		),
+		mcp.WithString("ports",
+			mcp.Description("Port range to scan (e.g. '80', '1-1024', '80,443,8080'). Scans common ports if omitted."),
+		),
+	), nmapHandler)
+
+	s.AddTool(mcp.NewTool("dns_lookup",
+		mcp.WithDescription("Perform DNS lookups for a domain, returning A, AAAA, MX, NS, and TXT records."),
+		mcp.WithString("domain",
+			mcp.Required(),
+			mcp.Description("Domain name to query (e.g. 'example.com')"),
+		),
+	), dnsHandler)
+
+	return s
+}
+
+func nmapHandler(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	target, ok := req.Params.Arguments["target"].(string)
+	if !ok || target == "" {
+		return mcp.NewToolResultError("target parameter is required"), nil
+	}
+
+	ports, _ := req.Params.Arguments["ports"].(string)
+
+	result, err := nmap.Scan(target, ports)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("nmap scan failed: %v", err)), nil
+	}
+	return mcp.NewToolResultText(result), nil
+}
+
+func dnsHandler(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	domain, ok := req.Params.Arguments["domain"].(string)
+	if !ok || domain == "" {
+		return mcp.NewToolResultError("domain parameter is required"), nil
+	}
+
+	result, err := dns.Lookup(domain)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("DNS lookup failed: %v", err)), nil
+	}
+	return mcp.NewToolResultText(result), nil
+}

--- a/tools/dns/dns.go
+++ b/tools/dns/dns.go
@@ -1,0 +1,67 @@
+package dns
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strings"
+)
+
+// validDomain restricts input to safe domain name characters.
+var validDomain = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// Lookup performs A/AAAA, MX, NS, and TXT DNS lookups for domain and returns
+// a human-readable summary. An error is returned only for invalid input; DNS
+// resolution failures for individual record types are silently skipped so that
+// partial results are still returned.
+func Lookup(domain string) (string, error) {
+	if domain == "" {
+		return "", fmt.Errorf("domain must not be empty")
+	}
+	if !validDomain.MatchString(domain) {
+		return "", fmt.Errorf("invalid domain %q: only alphanumeric characters, dots, hyphens are allowed", domain)
+	}
+
+	var sb strings.Builder
+
+	// A / AAAA records
+	addrs, err := net.LookupHost(domain)
+	if err == nil && len(addrs) > 0 {
+		sb.WriteString("A/AAAA records:\n")
+		for _, addr := range addrs {
+			fmt.Fprintf(&sb, "  %s\n", addr)
+		}
+	}
+
+	// MX records
+	mxRecords, err := net.LookupMX(domain)
+	if err == nil && len(mxRecords) > 0 {
+		sb.WriteString("MX records:\n")
+		for _, mx := range mxRecords {
+			fmt.Fprintf(&sb, "  %s (priority %d)\n", mx.Host, mx.Pref)
+		}
+	}
+
+	// NS records
+	nsRecords, err := net.LookupNS(domain)
+	if err == nil && len(nsRecords) > 0 {
+		sb.WriteString("NS records:\n")
+		for _, ns := range nsRecords {
+			fmt.Fprintf(&sb, "  %s\n", ns.Host)
+		}
+	}
+
+	// TXT records
+	txtRecords, err := net.LookupTXT(domain)
+	if err == nil && len(txtRecords) > 0 {
+		sb.WriteString("TXT records:\n")
+		for _, txt := range txtRecords {
+			fmt.Fprintf(&sb, "  %s\n", txt)
+		}
+	}
+
+	if sb.Len() == 0 {
+		return fmt.Sprintf("No DNS records found for %s\n", domain), nil
+	}
+	return sb.String(), nil
+}

--- a/tools/dns/dns_test.go
+++ b/tools/dns/dns_test.go
@@ -1,0 +1,50 @@
+package dns
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLookup_EmptyDomain(t *testing.T) {
+	_, err := Lookup("")
+	if err == nil {
+		t.Fatal("expected error for empty domain, got nil")
+	}
+}
+
+func TestLookup_InvalidDomain(t *testing.T) {
+	cases := []string{
+		"domain; rm -rf /",
+		"$(whoami)",
+		"domain && cat /etc/passwd",
+	}
+	for _, tc := range cases {
+		_, err := Lookup(tc)
+		if err == nil {
+			t.Errorf("expected error for domain %q, got nil", tc)
+		}
+	}
+}
+
+func TestLookup_ValidFormat(t *testing.T) {
+	// localhost should resolve on any system; if it doesn't, just check no panic.
+	result, err := Lookup("localhost")
+	if err != nil {
+		t.Fatalf("unexpected error for localhost: %v", err)
+	}
+	// Result should either contain records or the "No DNS records" message.
+	if result == "" {
+		t.Error("expected non-empty result")
+	}
+}
+
+func TestLookup_NoRecordsMessage(t *testing.T) {
+	// A domain that is unlikely to resolve.
+	result, err := Lookup("this-domain-does-not-exist-xyzzy123.invalid")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "No DNS records") && !strings.HasPrefix(result, "A/AAAA") {
+		t.Errorf("unexpected result: %q", result)
+	}
+}

--- a/tools/nmap/nmap.go
+++ b/tools/nmap/nmap.go
@@ -1,0 +1,39 @@
+package nmap
+
+import (
+	"fmt"
+	"regexp"
+
+	internexec "github.com/mycroft/sec-skills-mcp/internal/exec"
+)
+
+// validTarget allows hostnames and IP addresses (IPv4/IPv6 basic check).
+var validTarget = regexp.MustCompile(`^[a-zA-Z0-9._:\[\]-]+$`)
+
+// validPorts allows port numbers, ranges, and comma-separated lists.
+var validPorts = regexp.MustCompile(`^[0-9,\-]+$`)
+
+// Scan runs an nmap port scan against target. If ports is non-empty it is
+// passed as the -p argument. Returns combined nmap output or an error.
+func Scan(target, ports string) (string, error) {
+	if err := internexec.LookPath("nmap"); err != nil {
+		return "", fmt.Errorf("nmap not found in PATH: %w", err)
+	}
+
+	if target == "" {
+		return "", fmt.Errorf("target must not be empty")
+	}
+	if !validTarget.MatchString(target) {
+		return "", fmt.Errorf("invalid target %q: only alphanumeric characters, dots, hyphens, colons, and brackets are allowed", target)
+	}
+
+	args := []string{target}
+	if ports != "" {
+		if !validPorts.MatchString(ports) {
+			return "", fmt.Errorf("invalid port range %q: only digits, commas, and hyphens are allowed", ports)
+		}
+		args = append([]string{"-p", ports}, args...)
+	}
+
+	return internexec.Run("nmap", args...)
+}

--- a/tools/nmap/nmap_test.go
+++ b/tools/nmap/nmap_test.go
@@ -1,0 +1,57 @@
+package nmap
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestScan_MissingTarget(t *testing.T) {
+	_, err := Scan("", "")
+	if err == nil {
+		t.Fatal("expected error for empty target, got nil")
+	}
+}
+
+func TestScan_InvalidTarget(t *testing.T) {
+	cases := []string{
+		"host; rm -rf /",
+		"$(whoami)",
+		"host && cat /etc/passwd",
+		"host\x00name",
+	}
+	for _, tc := range cases {
+		_, err := Scan(tc, "")
+		if err == nil {
+			t.Errorf("expected error for target %q, got nil", tc)
+		}
+	}
+}
+
+func TestScan_InvalidPorts(t *testing.T) {
+	cases := []string{
+		"80; rm -rf /",
+		"$(whoami)",
+		"80 443",
+	}
+	for _, tc := range cases {
+		_, err := Scan("localhost", tc)
+		if err == nil {
+			t.Errorf("expected error for ports %q, got nil", tc)
+		}
+	}
+}
+
+func TestScan_Integration(t *testing.T) {
+	if _, err := exec.LookPath("nmap"); err != nil {
+		t.Skip("nmap not found, skipping integration test")
+	}
+
+	out, err := Scan("127.0.0.1", "80")
+	if err != nil {
+		// nmap may exit non-zero on some systems without root; just check output.
+		t.Logf("nmap returned error (may be expected without root): %v", err)
+	}
+	if out == "" {
+		t.Error("expected non-empty output from nmap")
+	}
+}


### PR DESCRIPTION
Implements the initial sec-skills-mcp project as described in issue #4.

Adds an MCP server with two security tools: nmap_scan and dns_lookup.

Generated with [Claude Code](https://claude.ai/code)