### PR TITLE
feat: add whois_lookup skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An MCP (Model Context Protocol) server written in Go that provides security tool
 
 - Go 1.22 or later
 - `nmap` installed and available in `PATH` (for the `nmap_scan` tool)
+- `whois` installed and available in `PATH` (for the `whois_lookup` tool)
 
 ## Installation
 
@@ -61,6 +62,16 @@ Perform DNS lookups for a domain, returning A, AAAA, MX, NS, and TXT records.
 | `domain`  | Yes      | Domain name to query (e.g. `example.com`) |
 
 **Example prompt**: "Look up DNS records for example.com"
+
+### `whois_lookup`
+
+Query WHOIS data for a domain or IP address to gather registrant info, creation dates, and ASN details.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `target`  | Yes      | Domain name or IP address to query (e.g. `example.com` or `8.8.8.8`) |
+
+**Example prompt**: "Get WHOIS information for example.com"
 
 ## Development
 

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mycroft/sec-skills-mcp/tools/dns"
 	"github.com/mycroft/sec-skills-mcp/tools/nmap"
+	"github.com/mycroft/sec-skills-mcp/tools/whois"
 )
 
 // New creates and returns a configured MCP server with all security tools registered.
@@ -38,6 +39,14 @@ func New() *server.MCPServer {
 		),
 	), dnsHandler)
 
+	s.AddTool(mcp.NewTool("whois_lookup",
+		mcp.WithDescription("Query WHOIS data for a domain or IP address to gather registrant info, creation dates, and ASN details. Useful for recon. Only use against targets you are authorized to investigate."),
+		mcp.WithString("target",
+			mcp.Required(),
+			mcp.Description("Domain name or IP address to query (e.g. 'example.com' or '8.8.8.8')"),
+		),
+	), whoisHandler)
+
 	return s
 }
 
@@ -52,6 +61,19 @@ func nmapHandler(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolRes
 	result, err := nmap.Scan(target, ports)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("nmap scan failed: %v", err)), nil
+	}
+	return mcp.NewToolResultText(result), nil
+}
+
+func whoisHandler(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	target, ok := req.Params.Arguments["target"].(string)
+	if !ok || target == "" {
+		return mcp.NewToolResultError("target parameter is required"), nil
+	}
+
+	result, err := whois.Lookup(target)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("whois lookup failed: %v", err)), nil
 	}
 	return mcp.NewToolResultText(result), nil
 }

--- a/tools/whois/whois.go
+++ b/tools/whois/whois.go
@@ -1,0 +1,29 @@
+package whois
+
+import (
+	"fmt"
+	"regexp"
+
+	internexec "github.com/mycroft/sec-skills-mcp/internal/exec"
+)
+
+// validTarget allows domain names and IP addresses (IPv4/IPv6).
+var validTarget = regexp.MustCompile(`^[a-zA-Z0-9._:\[\]-]+$`)
+
+// Lookup runs a whois query against target (domain or IP address) and returns
+// the raw whois output. Returns an error if the target is invalid or if the
+// whois binary is not available.
+func Lookup(target string) (string, error) {
+	if err := internexec.LookPath("whois"); err != nil {
+		return "", fmt.Errorf("whois not found in PATH: %w", err)
+	}
+
+	if target == "" {
+		return "", fmt.Errorf("target must not be empty")
+	}
+	if !validTarget.MatchString(target) {
+		return "", fmt.Errorf("invalid target %q: only alphanumeric characters, dots, hyphens, colons, and brackets are allowed", target)
+	}
+
+	return internexec.Run("whois", target)
+}

--- a/tools/whois/whois_test.go
+++ b/tools/whois/whois_test.go
@@ -1,0 +1,65 @@
+package whois
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestLookup_EmptyTarget(t *testing.T) {
+	_, err := Lookup("")
+	if err == nil {
+		t.Fatal("expected error for empty target, got nil")
+	}
+}
+
+func TestLookup_InvalidTarget(t *testing.T) {
+	cases := []string{
+		"domain; rm -rf /",
+		"$(whoami)",
+		"domain && cat /etc/passwd",
+		"domain|evil",
+	}
+	for _, tc := range cases {
+		_, err := Lookup(tc)
+		if err == nil {
+			t.Errorf("expected error for target %q, got nil", tc)
+		}
+	}
+}
+
+func TestLookup_WhoisNotFound(t *testing.T) {
+	if _, err := exec.LookPath("whois"); err == nil {
+		t.Skip("whois is available; skipping binary-not-found test")
+	}
+	_, err := Lookup("example.com")
+	if err == nil {
+		t.Fatal("expected error when whois binary is missing, got nil")
+	}
+}
+
+func TestLookup_ValidDomain(t *testing.T) {
+	if _, err := exec.LookPath("whois"); err != nil {
+		t.Skip("whois not found, skipping integration test")
+	}
+	result, err := Lookup("example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == "" {
+		t.Error("expected non-empty result for example.com")
+	}
+}
+
+func TestLookup_ValidIP(t *testing.T) {
+	if _, err := exec.LookPath("whois"); err != nil {
+		t.Skip("whois not found, skipping integration test")
+	}
+	// 8.8.8.8 is Google's public DNS — safe to query in tests.
+	result, err := Lookup("8.8.8.8")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == "" {
+		t.Error("expected non-empty result for 8.8.8.8")
+	}
+}


### PR DESCRIPTION
Implement a new MCP tool `whois_lookup` that queries WHOIS data for domains or IP addresses to gather registrant info, creation dates, and ASN details. Useful for the recon phase of authorized security testing.

Closes #6

Generated with [Claude Code](https://claude.ai/code)