### PR TITLE
feat: implement http_probe tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ Query WHOIS data for a domain or IP address to gather registrant info, creation 
 
 **Example prompt**: "Get WHOIS information for example.com"
 
+### `http_probe`
+
+Probe an HTTP/HTTPS URL to fingerprint web servers: detect technologies via response headers and cookies, record status codes and headers, and optionally check common paths for sensitive resources.
+
+| Parameter        | Required | Description |
+|-----------------|----------|-------------|
+| `target`         | Yes      | Full URL to probe (e.g. `https://example.com`) |
+| `check_paths`    | No       | When `true`, probe common paths such as `/robots.txt`, `/.git/HEAD`, `/admin`, `/.env`, etc. |
+| `skip_tls_verify`| No       | When `true`, skip TLS certificate verification (useful for self-signed certificates). |
+
+**Example prompt**: "Probe https://example.com and check common paths for sensitive files"
+
 ## Development
 
 ```bash

--- a/server/server.go
+++ b/server/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/mycroft/sec-skills-mcp/tools/dns"
+	http_probe "github.com/mycroft/sec-skills-mcp/tools/http_probe"
 	"github.com/mycroft/sec-skills-mcp/tools/nmap"
 	"github.com/mycroft/sec-skills-mcp/tools/whois"
 )
@@ -46,6 +47,20 @@ func New() *server.MCPServer {
 			mcp.Description("Domain name or IP address to query (e.g. 'example.com' or '8.8.8.8')"),
 		),
 	), whoisHandler)
+
+	s.AddTool(mcp.NewTool("http_probe",
+		mcp.WithDescription("Probe an HTTP/HTTPS target to fingerprint web servers: detect technologies via response headers and cookies, record status codes, and optionally check common paths for sensitive resources. Only use against targets you are authorized to test."),
+		mcp.WithString("target",
+			mcp.Required(),
+			mcp.Description("Full URL to probe (e.g. 'https://example.com')"),
+		),
+		mcp.WithBoolean("check_paths",
+			mcp.Description("When true, probe common paths such as /robots.txt, /.git/HEAD, /admin, /.env, etc. Defaults to false."),
+		),
+		mcp.WithBoolean("skip_tls_verify",
+			mcp.Description("When true, skip TLS certificate verification (useful for self-signed certs). Defaults to false."),
+		),
+	), httpProbeHandler)
 
 	return s
 }
@@ -87,6 +102,27 @@ func dnsHandler(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResu
 	result, err := dns.Lookup(domain)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("DNS lookup failed: %v", err)), nil
+	}
+	return mcp.NewToolResultText(result), nil
+}
+
+func httpProbeHandler(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	target, ok := req.Params.Arguments["target"].(string)
+	if !ok || target == "" {
+		return mcp.NewToolResultError("target parameter is required"), nil
+	}
+
+	checkPaths, _ := req.Params.Arguments["check_paths"].(bool)
+	skipTLS, _ := req.Params.Arguments["skip_tls_verify"].(bool)
+
+	opts := http_probe.ProbeOptions{
+		CheckPaths:    checkPaths,
+		SkipTLSVerify: skipTLS,
+	}
+
+	result, err := http_probe.Probe(target, opts)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("HTTP probe failed: %v", err)), nil
 	}
 	return mcp.NewToolResultText(result), nil
 }

--- a/tools/http_probe/http_probe.go
+++ b/tools/http_probe/http_probe.go
@@ -1,0 +1,223 @@
+package http_probe
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// commonPaths is the list of paths probed when check_paths is requested.
+var commonPaths = []string{
+	"/robots.txt",
+	"/.git/HEAD",
+	"/admin",
+	"/admin/",
+	"/.env",
+	"/wp-login.php",
+	"/phpmyadmin",
+	"/config.php",
+	"/.htaccess",
+	"/sitemap.xml",
+	"/crossdomain.xml",
+	"/server-status",
+	"/api",
+	"/api/v1",
+	"/.well-known/security.txt",
+}
+
+// techHeaders maps header names to technology labels.
+var techHeaders = map[string]string{
+	"server":           "Server",
+	"x-powered-by":     "X-Powered-By",
+	"x-generator":      "Generator",
+	"x-drupal-cache":   "Drupal",
+	"x-wordpress-id":   "WordPress",
+	"x-shopify-stage":  "Shopify",
+	"x-magento-vary":   "Magento",
+	"cf-ray":           "Cloudflare",
+	"x-amz-cf-id":      "AWS CloudFront",
+	"x-amz-request-id": "AWS",
+	"x-azure-ref":      "Azure CDN",
+	"x-varnish":        "Varnish",
+	"via":              "Proxy/CDN",
+}
+
+// newClient returns an HTTP client configured with a timeout and optional TLS
+// verification skip.
+func newClient(skipTLS bool) *http.Client {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipTLS}, //nolint:gosec
+	}
+	return &http.Client{
+		Timeout:   15 * time.Second,
+		Transport: transport,
+		// Do not follow redirects automatically; we report them explicitly.
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// ProbeOptions controls the behaviour of Probe.
+type ProbeOptions struct {
+	// CheckPaths probes commonPaths when true.
+	CheckPaths bool
+	// SkipTLSVerify disables TLS certificate validation.
+	SkipTLSVerify bool
+}
+
+// Probe performs an HTTP/HTTPS probe against target and returns a formatted
+// summary. target must be an http or https URL. Returns an error for invalid
+// input; network errors for individual path checks are reported inline.
+func Probe(target string, opts ProbeOptions) (string, error) {
+	if target == "" {
+		return "", fmt.Errorf("target URL must not be empty")
+	}
+
+	parsed, err := url.Parse(target)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL %q: %w", target, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("invalid URL scheme %q: only http and https are supported", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("invalid URL %q: host is missing", target)
+	}
+
+	client := newClient(opts.SkipTLSVerify)
+
+	var sb strings.Builder
+
+	// --- Main request ---
+	fmt.Fprintf(&sb, "Target: %s\n\n", target)
+
+	resp, err := client.Get(target) //nolint:noctx
+	if err != nil {
+		return "", fmt.Errorf("HTTP request to %q failed: %w", target, err)
+	}
+	defer resp.Body.Close()
+
+	fmt.Fprintf(&sb, "Status: %s\n", resp.Status)
+
+	// Redirect location
+	if loc := resp.Header.Get("Location"); loc != "" {
+		fmt.Fprintf(&sb, "Redirect: %s\n", loc)
+	}
+
+	// --- Response Headers ---
+	sb.WriteString("\nResponse Headers:\n")
+	for key, vals := range resp.Header {
+		fmt.Fprintf(&sb, "  %s: %s\n", key, strings.Join(vals, ", "))
+	}
+
+	// --- Technology Detection ---
+	detected := detectTechnologies(resp)
+	if len(detected) > 0 {
+		sb.WriteString("\nDetected Technologies:\n")
+		for _, tech := range detected {
+			fmt.Fprintf(&sb, "  %s\n", tech)
+		}
+	}
+
+	// --- Cookies ---
+	if cookies := resp.Cookies(); len(cookies) > 0 {
+		sb.WriteString("\nCookies:\n")
+		for _, c := range cookies {
+			attrs := []string{}
+			if c.HttpOnly {
+				attrs = append(attrs, "HttpOnly")
+			}
+			if c.Secure {
+				attrs = append(attrs, "Secure")
+			}
+			if c.SameSite != http.SameSiteDefaultMode {
+				attrs = append(attrs, fmt.Sprintf("SameSite=%s", sameSiteString(c.SameSite)))
+			}
+			attrStr := ""
+			if len(attrs) > 0 {
+				attrStr = " [" + strings.Join(attrs, ", ") + "]"
+			}
+			fmt.Fprintf(&sb, "  %s=%s%s\n", c.Name, c.Value, attrStr)
+		}
+	}
+
+	// --- Common Path Probing ---
+	if opts.CheckPaths {
+		sb.WriteString("\nCommon Path Probe:\n")
+		base := fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
+		for _, path := range commonPaths {
+			pathURL := base + path
+			presp, perr := client.Get(pathURL) //nolint:noctx
+			if perr != nil {
+				fmt.Fprintf(&sb, "  %s -> ERROR (%v)\n", path, perr)
+				continue
+			}
+			presp.Body.Close()
+			fmt.Fprintf(&sb, "  %s -> %s\n", path, presp.Status)
+		}
+	}
+
+	return sb.String(), nil
+}
+
+// detectTechnologies inspects the response headers and cookies for technology
+// fingerprints and returns a deduplicated list of human-readable labels.
+func detectTechnologies(resp *http.Response) []string {
+	seen := map[string]bool{}
+	var result []string
+
+	add := func(label string) {
+		if !seen[label] {
+			seen[label] = true
+			result = append(result, label)
+		}
+	}
+
+	for header, label := range techHeaders {
+		if val := resp.Header.Get(header); val != "" {
+			if label == "Server" || label == "X-Powered-By" || label == "Proxy/CDN" || label == "Generator" {
+				add(fmt.Sprintf("%s: %s", label, val))
+			} else {
+				add(label)
+			}
+		}
+	}
+
+	// Cookie-based tech fingerprinting
+	for _, c := range resp.Cookies() {
+		name := strings.ToLower(c.Name)
+		switch {
+		case strings.HasPrefix(name, "phpsessid"):
+			add("PHP")
+		case strings.HasPrefix(name, "laravel_session"):
+			add("Laravel (PHP)")
+		case strings.HasPrefix(name, "asp.net_sessionid"), strings.HasPrefix(name, "aspsessionid"):
+			add("ASP.NET")
+		case strings.HasPrefix(name, "jsessionid"):
+			add("Java/J2EE")
+		case strings.HasPrefix(name, "wordpress_"):
+			add("WordPress")
+		case name == "drupal_uid":
+			add("Drupal")
+		}
+	}
+
+	return result
+}
+
+func sameSiteString(s http.SameSite) string {
+	switch s {
+	case http.SameSiteLaxMode:
+		return "Lax"
+	case http.SameSiteStrictMode:
+		return "Strict"
+	case http.SameSiteNoneMode:
+		return "None"
+	default:
+		return "Default"
+	}
+}

--- a/tools/http_probe/http_probe_test.go
+++ b/tools/http_probe/http_probe_test.go
@@ -1,0 +1,191 @@
+package http_probe
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestProbe_EmptyURL(t *testing.T) {
+	_, err := Probe("", ProbeOptions{})
+	if err == nil {
+		t.Fatal("expected error for empty URL, got nil")
+	}
+}
+
+func TestProbe_InvalidScheme(t *testing.T) {
+	cases := []string{
+		"ftp://example.com",
+		"file:///etc/passwd",
+		"javascript:alert(1)",
+	}
+	for _, tc := range cases {
+		_, err := Probe(tc, ProbeOptions{})
+		if err == nil {
+			t.Errorf("expected error for URL %q, got nil", tc)
+		}
+	}
+}
+
+func TestProbe_InvalidURL(t *testing.T) {
+	cases := []string{
+		"not-a-url",
+		"http://",
+		"://missing-scheme",
+	}
+	for _, tc := range cases {
+		_, err := Probe(tc, ProbeOptions{})
+		if err == nil {
+			t.Errorf("expected error for URL %q, got nil", tc)
+		}
+	}
+}
+
+func TestProbe_BasicRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Server", "TestServer/1.0")
+		w.Header().Set("X-Powered-By", "Go")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	result, err := Probe(srv.URL, ProbeOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "200 OK") {
+		t.Errorf("expected status 200 OK in result, got:\n%s", result)
+	}
+	if !strings.Contains(result, "TestServer/1.0") {
+		t.Errorf("expected Server header in result, got:\n%s", result)
+	}
+	if !strings.Contains(result, "Server: TestServer/1.0") {
+		t.Errorf("expected technology detection for Server header, got:\n%s", result)
+	}
+}
+
+func TestProbe_TechDetection_XPoweredBy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Powered-By", "PHP/8.1")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	result, err := Probe(srv.URL, ProbeOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "X-Powered-By: PHP/8.1") {
+		t.Errorf("expected X-Powered-By detection, got:\n%s", result)
+	}
+}
+
+func TestProbe_TechDetection_Cloudflare(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("CF-Ray", "abc123-LAX")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	result, err := Probe(srv.URL, ProbeOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "Cloudflare") {
+		t.Errorf("expected Cloudflare detection, got:\n%s", result)
+	}
+}
+
+func TestProbe_CookieDetection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{
+			Name:     "PHPSESSID",
+			Value:    "abc123",
+			HttpOnly: true,
+			Secure:   false,
+		})
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	result, err := Probe(srv.URL, ProbeOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "PHPSESSID") {
+		t.Errorf("expected PHPSESSID cookie in result, got:\n%s", result)
+	}
+	if !strings.Contains(result, "PHP") {
+		t.Errorf("expected PHP technology detection via cookie, got:\n%s", result)
+	}
+	if !strings.Contains(result, "HttpOnly") {
+		t.Errorf("expected HttpOnly attribute in cookie output, got:\n%s", result)
+	}
+}
+
+func TestProbe_Redirect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://example.com/new", http.StatusMovedPermanently)
+	}))
+	defer srv.Close()
+
+	result, err := Probe(srv.URL, ProbeOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "301") {
+		t.Errorf("expected 301 status in result, got:\n%s", result)
+	}
+	if !strings.Contains(result, "Redirect:") {
+		t.Errorf("expected Redirect line in result, got:\n%s", result)
+	}
+}
+
+func TestProbe_CheckPaths(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/robots.txt", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("User-agent: *\nDisallow: /admin\n")) //nolint:errcheck
+	})
+	mux.HandleFunc("/.git/HEAD", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ref: refs/heads/main\n")) //nolint:errcheck
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	result, err := Probe(srv.URL, ProbeOptions{CheckPaths: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "Common Path Probe:") {
+		t.Errorf("expected 'Common Path Probe:' section, got:\n%s", result)
+	}
+	if !strings.Contains(result, "/robots.txt") {
+		t.Errorf("expected /robots.txt probe, got:\n%s", result)
+	}
+	if !strings.Contains(result, "/.git/HEAD") {
+		t.Errorf("expected /.git/HEAD probe, got:\n%s", result)
+	}
+}
+
+func TestProbe_NoPaths_WhenNotRequested(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	result, err := Probe(srv.URL, ProbeOptions{CheckPaths: false})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(result, "Common Path Probe:") {
+		t.Errorf("did not expect path probe section when CheckPaths=false, got:\n%s", result)
+	}
+}


### PR DESCRIPTION
Implement the `http_probe` MCP tool that performs HTTP/HTTPS requests to fingerprint web servers: detect technologies via headers and cookies, check common paths, and record response codes/headers.

Closes #8

Generated with [Claude Code](https://claude.ai/code)