### PR TITLE
feat: add ssl_inspect skill for TLS/SSL certificate analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ Probe an HTTP/HTTPS URL to fingerprint web servers: detect technologies via resp
 
 **Example prompt**: "Probe https://example.com and check common paths for sensitive files"
 
+### `ssl_inspect`
+
+Analyze TLS/SSL certificates and configuration for a host: check certificate expiry, issuer chain, Subject Alternative Names (SANs), weak cipher suites, and supported protocol versions (TLS 1.0/1.1 detection).
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `host`    | Yes      | Hostname to inspect (e.g. `example.com`) |
+| `port`    | No       | TCP port to connect to (default: `443`) |
+
+**Example prompt**: "Inspect the TLS configuration of example.com"
+
 ## Development
 
 ```bash

--- a/server/server.go
+++ b/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mycroft/sec-skills-mcp/tools/dns"
 	http_probe "github.com/mycroft/sec-skills-mcp/tools/http_probe"
 	"github.com/mycroft/sec-skills-mcp/tools/nmap"
+	ssl_inspect "github.com/mycroft/sec-skills-mcp/tools/ssl_inspect"
 	"github.com/mycroft/sec-skills-mcp/tools/whois"
 )
 
@@ -48,6 +49,17 @@ func New() *server.MCPServer {
 		),
 	), whoisHandler)
 
+	s.AddTool(mcp.NewTool("ssl_inspect",
+		mcp.WithDescription("Analyze TLS/SSL certificates and configuration for a host: check certificate expiry, issuer chain, Subject Alternative Names (SANs), weak cipher suites, and supported protocol versions including TLS 1.0/1.1 detection. Only use against hosts you are authorized to test."),
+		mcp.WithString("host",
+			mcp.Required(),
+			mcp.Description("Hostname to inspect (e.g. 'example.com')"),
+		),
+		mcp.WithString("port",
+			mcp.Description("TCP port to connect to (default: 443)"),
+		),
+	), sslInspectHandler)
+
 	s.AddTool(mcp.NewTool("http_probe",
 		mcp.WithDescription("Probe an HTTP/HTTPS target to fingerprint web servers: detect technologies via response headers and cookies, record status codes, and optionally check common paths for sensitive resources. Only use against targets you are authorized to test."),
 		mcp.WithString("target",
@@ -63,6 +75,21 @@ func New() *server.MCPServer {
 	), httpProbeHandler)
 
 	return s
+}
+
+func sslInspectHandler(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	host, ok := req.Params.Arguments["host"].(string)
+	if !ok || host == "" {
+		return mcp.NewToolResultError("host parameter is required"), nil
+	}
+
+	port, _ := req.Params.Arguments["port"].(string)
+
+	result, err := ssl_inspect.Inspect(host, port)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("SSL inspection failed: %v", err)), nil
+	}
+	return mcp.NewToolResultText(result), nil
 }
 
 func nmapHandler(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/tools/ssl_inspect/ssl_inspect.go
+++ b/tools/ssl_inspect/ssl_inspect.go
@@ -1,0 +1,208 @@
+package ssl_inspect
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// validHost restricts input to safe hostname characters.
+var validHost = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// Inspect performs TLS/SSL inspection on the given host and port and returns a
+// human-readable summary covering:
+//   - Leaf certificate details (subject, issuer, expiry, SANs)
+//   - Certificate chain
+//   - Supported TLS protocol versions (with warnings for TLS 1.0/1.1)
+//   - Weak cipher suite support
+func Inspect(host, port string) (string, error) {
+	if host == "" {
+		return "", fmt.Errorf("host must not be empty")
+	}
+	if !validHost.MatchString(host) {
+		return "", fmt.Errorf("invalid host %q: only alphanumeric characters, dots, and hyphens are allowed", host)
+	}
+
+	if port == "" {
+		port = "443"
+	}
+	portNum, err := strconv.Atoi(port)
+	if err != nil || portNum < 1 || portNum > 65535 {
+		return "", fmt.Errorf("invalid port %q: must be a number between 1 and 65535", port)
+	}
+
+	addr := net.JoinHostPort(host, port)
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "SSL/TLS Inspection: %s\n\n", addr)
+
+	// Connect with verification first; fall back to InsecureSkipVerify so we
+	// can still inspect the certificate even when it is self-signed or expired.
+	conn, certErr := tls.DialWithDialer(
+		&net.Dialer{Timeout: 10 * time.Second},
+		"tcp",
+		addr,
+		&tls.Config{ServerName: host},
+	)
+	if certErr != nil {
+		conn, err = tls.DialWithDialer(
+			&net.Dialer{Timeout: 10 * time.Second},
+			"tcp",
+			addr,
+			&tls.Config{
+				ServerName:         host,
+				InsecureSkipVerify: true, //nolint:gosec
+			},
+		)
+		if err != nil {
+			return "", fmt.Errorf("failed to connect to %s: %w", addr, err)
+		}
+		fmt.Fprintf(&sb, "WARNING: Certificate verification failed: %v\n\n", certErr)
+	}
+
+	state := conn.ConnectionState()
+	conn.Close()
+
+	// --- Leaf certificate ---
+	if len(state.PeerCertificates) > 0 {
+		leaf := state.PeerCertificates[0]
+
+		sb.WriteString("=== Leaf Certificate ===\n")
+		fmt.Fprintf(&sb, "Subject CN:  %s\n", leaf.Subject.CommonName)
+		fmt.Fprintf(&sb, "Issuer CN:   %s\n", leaf.Issuer.CommonName)
+		fmt.Fprintf(&sb, "Valid From:  %s\n", leaf.NotBefore.UTC().Format(time.RFC3339))
+		fmt.Fprintf(&sb, "Valid Until: %s\n", leaf.NotAfter.UTC().Format(time.RFC3339))
+
+		daysLeft := time.Until(leaf.NotAfter).Hours() / 24
+		switch {
+		case daysLeft < 0:
+			fmt.Fprintf(&sb, "Expiry:      EXPIRED (%.0f days ago)\n", -daysLeft)
+		case daysLeft < 14:
+			fmt.Fprintf(&sb, "Expiry:      CRITICAL – expires in %.0f days\n", daysLeft)
+		case daysLeft < 30:
+			fmt.Fprintf(&sb, "Expiry:      WARNING – expires in %.0f days\n", daysLeft)
+		default:
+			fmt.Fprintf(&sb, "Expiry:      OK (%.0f days remaining)\n", daysLeft)
+		}
+
+		// Subject Alternative Names
+		var sans []string
+		sans = append(sans, leaf.DNSNames...)
+		for _, ip := range leaf.IPAddresses {
+			sans = append(sans, ip.String())
+		}
+		for _, uri := range leaf.URIs {
+			sans = append(sans, uri.String())
+		}
+		if len(sans) > 0 {
+			sb.WriteString("SANs:\n")
+			for _, san := range sans {
+				fmt.Fprintf(&sb, "  %s\n", san)
+			}
+		}
+
+		// --- Certificate chain ---
+		if len(state.PeerCertificates) > 1 {
+			sb.WriteString("\n=== Certificate Chain ===\n")
+			for i, cert := range state.PeerCertificates {
+				role := "Intermediate CA"
+				if i == 0 {
+					role = "Leaf"
+				} else if cert.IsCA && i == len(state.PeerCertificates)-1 {
+					role = "Root CA"
+				}
+				fmt.Fprintf(&sb, "[%d] %-15s %s\n", i, role, cert.Subject.CommonName)
+				if cert.Issuer.CommonName != cert.Subject.CommonName {
+					fmt.Fprintf(&sb, "         Issuer: %s\n", cert.Issuer.CommonName)
+				}
+			}
+		}
+	}
+
+	// --- Protocol version support ---
+	sb.WriteString("\n=== Protocol Version Support ===\n")
+	protos := []struct {
+		name     string
+		version  uint16
+		insecure bool
+	}{
+		{"TLS 1.0", tls.VersionTLS10, true},
+		{"TLS 1.1", tls.VersionTLS11, true},
+		{"TLS 1.2", tls.VersionTLS12, false},
+		{"TLS 1.3", tls.VersionTLS13, false},
+	}
+	for _, p := range protos {
+		if checkProtocolVersion(addr, host, p.version) {
+			if p.insecure {
+				fmt.Fprintf(&sb, "  %-8s SUPPORTED (INSECURE – should be disabled)\n", p.name)
+			} else {
+				fmt.Fprintf(&sb, "  %-8s Supported\n", p.name)
+			}
+		} else {
+			fmt.Fprintf(&sb, "  %-8s Not supported\n", p.name)
+		}
+	}
+
+	// --- Weak cipher suite detection ---
+	sb.WriteString("\n=== Weak Cipher Suite Detection ===\n")
+	weakFound := false
+	for _, cs := range tls.InsecureCipherSuites() {
+		if checkCipherSuite(addr, host, cs.ID) {
+			fmt.Fprintf(&sb, "  WEAK: %s\n", cs.Name)
+			weakFound = true
+		}
+	}
+	if !weakFound {
+		sb.WriteString("  No weak cipher suites detected\n")
+	}
+
+	return sb.String(), nil
+}
+
+// checkProtocolVersion attempts a TLS handshake pinned to exactly version and
+// returns true if the server accepts it.
+func checkProtocolVersion(addr, host string, version uint16) bool {
+	conn, err := tls.DialWithDialer(
+		&net.Dialer{Timeout: 5 * time.Second},
+		"tcp",
+		addr,
+		&tls.Config{
+			ServerName:         host,
+			InsecureSkipVerify: true, //nolint:gosec
+			MinVersion:         version,
+			MaxVersion:         version,
+		},
+	)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// checkCipherSuite attempts a TLS 1.2 handshake offering only cipherID and
+// returns true if the server negotiates it.  TLS 1.3 has fixed cipher suites
+// so weak-cipher testing only applies to TLS 1.2 and below.
+func checkCipherSuite(addr, host string, cipherID uint16) bool {
+	conn, err := tls.DialWithDialer(
+		&net.Dialer{Timeout: 5 * time.Second},
+		"tcp",
+		addr,
+		&tls.Config{
+			ServerName:         host,
+			InsecureSkipVerify: true,            //nolint:gosec
+			MinVersion:         tls.VersionTLS10, //nolint:gosec
+			MaxVersion:         tls.VersionTLS12,
+			CipherSuites:       []uint16{cipherID},
+		},
+	)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}

--- a/tools/ssl_inspect/ssl_inspect_test.go
+++ b/tools/ssl_inspect/ssl_inspect_test.go
@@ -1,0 +1,75 @@
+package ssl_inspect
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInspect_EmptyHost(t *testing.T) {
+	_, err := Inspect("", "443")
+	if err == nil {
+		t.Fatal("expected error for empty host, got nil")
+	}
+}
+
+func TestInspect_InvalidHost(t *testing.T) {
+	cases := []string{
+		"host; rm -rf /",
+		"$(whoami)",
+		"host && cat /etc/passwd",
+		"host\x00null",
+	}
+	for _, tc := range cases {
+		_, err := Inspect(tc, "443")
+		if err == nil {
+			t.Errorf("expected error for host %q, got nil", tc)
+		}
+	}
+}
+
+func TestInspect_InvalidPort(t *testing.T) {
+	cases := []struct {
+		port string
+		desc string
+	}{
+		{"not-a-port", "non-numeric port"},
+		{"0", "port zero"},
+		{"65536", "port out of range"},
+		{"-1", "negative port"},
+	}
+	for _, tc := range cases {
+		_, err := Inspect("example.com", tc.port)
+		if err == nil {
+			t.Errorf("expected error for %s (%q), got nil", tc.desc, tc.port)
+		}
+	}
+}
+
+func TestInspect_DefaultPort(t *testing.T) {
+	// Passing an empty port should not return a validation error; a connection
+	// error is acceptable (the test environment may not have network access).
+	// We just verify no input-validation error is returned.
+	_, err := Inspect("example.com", "")
+	if err != nil && strings.Contains(err.Error(), "invalid port") {
+		t.Errorf("empty port should default to 443, not return an invalid-port error: %v", err)
+	}
+}
+
+func TestInspect_Integration(t *testing.T) {
+	result, err := Inspect("example.com", "443")
+	if err != nil {
+		t.Skipf("network unavailable or connection failed: %v", err)
+	}
+
+	checks := []string{
+		"SSL/TLS Inspection",
+		"Leaf Certificate",
+		"Protocol Version Support",
+		"Weak Cipher Suite",
+	}
+	for _, check := range checks {
+		if !strings.Contains(result, check) {
+			t.Errorf("expected %q in result; got:\n%s", check, result)
+		}
+	}
+}


### PR DESCRIPTION
Implements the ssl_inspect MCP tool that connects to a host and reports:
- Leaf certificate details (subject, issuer, expiry status, SANs)
- Full certificate chain with role labels
- Supported TLS protocol versions with warnings for insecure TLS 1.0/1.1
- Weak cipher suite detection using Go's tls.InsecureCipherSuites()

Closes #10

Generated with [Claude Code](https://claude.ai/code)