### PR TITLE
feat: implement subdomain_enum tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ An MCP (Model Context Protocol) server written in Go that provides security tool
 - Go 1.22 or later
 - `nmap` installed and available in `PATH` (for the `nmap_scan` tool)
 - `whois` installed and available in `PATH` (for the `whois_lookup` tool)
+- `gobuster` installed and available in `PATH` (optional, for the `subdomain_enum` tool with `gobuster` method)
+- `ffuf` installed and available in `PATH` (optional, for the `subdomain_enum` tool with `ffuf` method)
 
 ## Installation
 
@@ -95,6 +97,25 @@ Analyze TLS/SSL certificates and configuration for a host: check certificate exp
 | `port`    | No       | TCP port to connect to (default: `443`) |
 
 **Example prompt**: "Inspect the TLS configuration of example.com"
+
+### `subdomain_enum`
+
+Enumerate subdomains for a domain using certificate transparency logs or wordlist brute-forcing.
+
+| Parameter  | Required | Description |
+|------------|----------|-------------|
+| `domain`   | Yes      | Target domain to enumerate subdomains for (e.g. `example.com`) |
+| `method`   | No       | Enumeration method: `crtsh` (default), `gobuster`, or `ffuf` |
+| `wordlist` | No       | Path to wordlist file (required for `gobuster` and `ffuf` methods) |
+
+**Methods:**
+- `crtsh` (default): Queries the [crt.sh](https://crt.sh) certificate transparency log API — no external tools required.
+- `gobuster`: Brute-forces DNS subdomains using `gobuster dns`. Requires `gobuster` in `PATH` and a wordlist.
+- `ffuf`: Brute-forces subdomains via HTTP using `ffuf`. Requires `ffuf` in `PATH` and a wordlist.
+
+**Example prompts**:
+- "Find subdomains of example.com using certificate transparency logs"
+- "Brute-force subdomains of example.com with gobuster using /usr/share/wordlists/subdomains.txt"
 
 ## Development
 

--- a/server/server.go
+++ b/server/server.go
@@ -11,6 +11,7 @@ import (
 	http_probe "github.com/mycroft/sec-skills-mcp/tools/http_probe"
 	"github.com/mycroft/sec-skills-mcp/tools/nmap"
 	ssl_inspect "github.com/mycroft/sec-skills-mcp/tools/ssl_inspect"
+	subdomain_enum "github.com/mycroft/sec-skills-mcp/tools/subdomain_enum"
 	"github.com/mycroft/sec-skills-mcp/tools/whois"
 )
 
@@ -74,6 +75,20 @@ func New() *server.MCPServer {
 		),
 	), httpProbeHandler)
 
+	s.AddTool(mcp.NewTool("subdomain_enum",
+		mcp.WithDescription("Enumerate subdomains for a domain using certificate transparency logs (crt.sh) or wordlist brute-forcing (gobuster/ffuf). Only use against domains you are authorized to test."),
+		mcp.WithString("domain",
+			mcp.Required(),
+			mcp.Description("Target domain to enumerate subdomains for (e.g. 'example.com')"),
+		),
+		mcp.WithString("method",
+			mcp.Description("Enumeration method: 'crtsh' (certificate transparency logs, default), 'gobuster' (DNS brute-force), or 'ffuf' (HTTP brute-force)"),
+		),
+		mcp.WithString("wordlist",
+			mcp.Description("Path to wordlist file (required for gobuster and ffuf methods)"),
+		),
+	), subdomainEnumHandler)
+
 	return s
 }
 
@@ -129,6 +144,27 @@ func dnsHandler(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResu
 	result, err := dns.Lookup(domain)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("DNS lookup failed: %v", err)), nil
+	}
+	return mcp.NewToolResultText(result), nil
+}
+
+func subdomainEnumHandler(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	domain, ok := req.Params.Arguments["domain"].(string)
+	if !ok || domain == "" {
+		return mcp.NewToolResultError("domain parameter is required"), nil
+	}
+
+	method, _ := req.Params.Arguments["method"].(string)
+	wordlist, _ := req.Params.Arguments["wordlist"].(string)
+
+	opts := subdomain_enum.EnumOptions{
+		Method:   method,
+		Wordlist: wordlist,
+	}
+
+	result, err := subdomain_enum.Enumerate(domain, opts)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("subdomain enumeration failed: %v", err)), nil
 	}
 	return mcp.NewToolResultText(result), nil
 }

--- a/tools/subdomain_enum/subdomain_enum.go
+++ b/tools/subdomain_enum/subdomain_enum.go
@@ -1,0 +1,179 @@
+package subdomain_enum
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	internexec "github.com/mycroft/sec-skills-mcp/internal/exec"
+)
+
+// validDomain restricts input to safe domain name characters.
+var validDomain = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// validPath allows safe file system path characters for wordlist paths.
+var validPath = regexp.MustCompile(`^[a-zA-Z0-9._/\-]+$`)
+
+// crtshEntry represents a single entry from the crt.sh JSON response.
+type crtshEntry struct {
+	NameValue string `json:"name_value"`
+}
+
+// EnumOptions holds configuration for subdomain enumeration.
+type EnumOptions struct {
+	// Method selects the enumeration method: "crtsh", "gobuster", or "ffuf".
+	// Defaults to "crtsh" if empty.
+	Method string
+	// Wordlist is the path to the wordlist file (required for gobuster and ffuf).
+	Wordlist string
+}
+
+// Enumerate discovers subdomains for domain using the configured method.
+func Enumerate(domain string, opts EnumOptions) (string, error) {
+	if domain == "" {
+		return "", fmt.Errorf("domain must not be empty")
+	}
+	if !validDomain.MatchString(domain) {
+		return "", fmt.Errorf("invalid domain %q: only alphanumeric characters, dots, and hyphens are allowed", domain)
+	}
+
+	method := opts.Method
+	if method == "" {
+		method = "crtsh"
+	}
+
+	switch method {
+	case "crtsh":
+		return enumCrtsh(domain)
+	case "gobuster":
+		return enumGobuster(domain, opts.Wordlist)
+	case "ffuf":
+		return enumFfuf(domain, opts.Wordlist)
+	default:
+		return "", fmt.Errorf("unknown method %q: must be one of crtsh, gobuster, ffuf", method)
+	}
+}
+
+// enumCrtsh queries the crt.sh certificate transparency log API to discover subdomains.
+func enumCrtsh(domain string) (string, error) {
+	url := fmt.Sprintf("https://crt.sh/?q=%%.%s&output=json", domain)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("crt.sh request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("crt.sh returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading crt.sh response: %w", err)
+	}
+
+	var entries []crtshEntry
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return "", fmt.Errorf("parsing crt.sh JSON response: %w", err)
+	}
+
+	// Deduplicate and collect subdomains.
+	seen := make(map[string]struct{})
+	for _, e := range entries {
+		// name_value can contain multiple names separated by newlines.
+		for _, name := range strings.Split(e.NameValue, "\n") {
+			name = strings.TrimSpace(strings.ToLower(name))
+			// Skip wildcards and entries that are not subdomains of the target.
+			if strings.HasPrefix(name, "*.") {
+				name = name[2:]
+			}
+			if name == "" || name == domain {
+				continue
+			}
+			// Only keep actual subdomains of the target domain.
+			if !strings.HasSuffix(name, "."+domain) {
+				continue
+			}
+			seen[name] = struct{}{}
+		}
+	}
+
+	if len(seen) == 0 {
+		return fmt.Sprintf("No subdomains found for %s via crt.sh\n", domain), nil
+	}
+
+	subdomains := make([]string, 0, len(seen))
+	for s := range seen {
+		subdomains = append(subdomains, s)
+	}
+	sort.Strings(subdomains)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Subdomains found for %s via crt.sh (%d):\n", domain, len(subdomains))
+	for _, s := range subdomains {
+		fmt.Fprintf(&sb, "  %s\n", s)
+	}
+	return sb.String(), nil
+}
+
+// enumGobuster runs gobuster in DNS mode to brute-force subdomains.
+func enumGobuster(domain, wordlist string) (string, error) {
+	if err := internexec.LookPath("gobuster"); err != nil {
+		return "", fmt.Errorf("gobuster not found in PATH: %w", err)
+	}
+	if wordlist == "" {
+		return "", fmt.Errorf("wordlist path is required for gobuster method")
+	}
+	if !validPath.MatchString(wordlist) {
+		return "", fmt.Errorf("invalid wordlist path %q", wordlist)
+	}
+
+	output, err := internexec.Run("gobuster", "dns", "-d", domain, "-w", wordlist, "--no-color")
+	if err != nil {
+		// gobuster exits non-zero even on partial results; return output regardless.
+		if output != "" {
+			return fmt.Sprintf("gobuster output (exit error: %v):\n%s", err, output), nil
+		}
+		return "", fmt.Errorf("gobuster failed: %w", err)
+	}
+	if output == "" {
+		return fmt.Sprintf("No subdomains found for %s via gobuster\n", domain), nil
+	}
+	return output, nil
+}
+
+// enumFfuf runs ffuf to brute-force subdomains via DNS resolution.
+func enumFfuf(domain, wordlist string) (string, error) {
+	if err := internexec.LookPath("ffuf"); err != nil {
+		return "", fmt.Errorf("ffuf not found in PATH: %w", err)
+	}
+	if wordlist == "" {
+		return "", fmt.Errorf("wordlist path is required for ffuf method")
+	}
+	if !validPath.MatchString(wordlist) {
+		return "", fmt.Errorf("invalid wordlist path %q", wordlist)
+	}
+
+	// Use ffuf with a virtual-host style URL pattern. The -fs flag filters by
+	// response size to reduce false positives; we keep all responses here and
+	// let the caller decide. -mc all captures all status codes.
+	url := fmt.Sprintf("http://FUZZ.%s", domain)
+	output, err := internexec.Run("ffuf", "-w", wordlist+":FUZZ", "-u", url, "-mc", "all", "-of", "json")
+	if err != nil {
+		if output != "" {
+			return fmt.Sprintf("ffuf output (exit error: %v):\n%s", err, output), nil
+		}
+		return "", fmt.Errorf("ffuf failed: %w", err)
+	}
+	if output == "" {
+		return fmt.Sprintf("No subdomains found for %s via ffuf\n", domain), nil
+	}
+	return output, nil
+}

--- a/tools/subdomain_enum/subdomain_enum_test.go
+++ b/tools/subdomain_enum/subdomain_enum_test.go
@@ -1,0 +1,127 @@
+package subdomain_enum
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestEnumerate_EmptyDomain(t *testing.T) {
+	_, err := Enumerate("", EnumOptions{})
+	if err == nil {
+		t.Fatal("expected error for empty domain, got nil")
+	}
+}
+
+func TestEnumerate_InvalidDomain(t *testing.T) {
+	cases := []string{
+		"domain; rm -rf /",
+		"$(whoami)",
+		"domain && cat /etc/passwd",
+		"domain|id",
+	}
+	for _, tc := range cases {
+		_, err := Enumerate(tc, EnumOptions{})
+		if err == nil {
+			t.Errorf("expected error for domain %q, got nil", tc)
+		}
+	}
+}
+
+func TestEnumerate_UnknownMethod(t *testing.T) {
+	_, err := Enumerate("example.com", EnumOptions{Method: "nmap"})
+	if err == nil {
+		t.Fatal("expected error for unknown method, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown method") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestEnumerate_GobusterMissingWordlist(t *testing.T) {
+	if _, err := exec.LookPath("gobuster"); err != nil {
+		t.Skip("gobuster not found, skipping")
+	}
+	_, err := Enumerate("example.com", EnumOptions{Method: "gobuster"})
+	if err == nil {
+		t.Fatal("expected error when wordlist is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "wordlist") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestEnumerate_FfufMissingWordlist(t *testing.T) {
+	if _, err := exec.LookPath("ffuf"); err != nil {
+		t.Skip("ffuf not found, skipping")
+	}
+	_, err := Enumerate("example.com", EnumOptions{Method: "ffuf"})
+	if err == nil {
+		t.Fatal("expected error when wordlist is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "wordlist") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestEnumerate_GobusterNotFound(t *testing.T) {
+	if _, err := exec.LookPath("gobuster"); err == nil {
+		t.Skip("gobuster found in PATH, skipping not-found test")
+	}
+	_, err := Enumerate("example.com", EnumOptions{Method: "gobuster", Wordlist: "/usr/share/wordlists/subdomains.txt"})
+	if err == nil {
+		t.Fatal("expected error when gobuster is not installed, got nil")
+	}
+	if !strings.Contains(err.Error(), "gobuster not found") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestEnumerate_FfufNotFound(t *testing.T) {
+	if _, err := exec.LookPath("ffuf"); err == nil {
+		t.Skip("ffuf found in PATH, skipping not-found test")
+	}
+	_, err := Enumerate("example.com", EnumOptions{Method: "ffuf", Wordlist: "/usr/share/wordlists/subdomains.txt"})
+	if err == nil {
+		t.Fatal("expected error when ffuf is not installed, got nil")
+	}
+	if !strings.Contains(err.Error(), "ffuf not found") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestEnumerate_InvalidWordlistPath(t *testing.T) {
+	cases := []struct {
+		method   string
+		wordlist string
+	}{
+		{"gobuster", "/path/with spaces/wordlist.txt"},
+		{"gobuster", "/path;rm -rf /"},
+		{"ffuf", "/path/with spaces/wordlist.txt"},
+		{"ffuf", "/path;rm -rf /"},
+	}
+	for _, tc := range cases {
+		_, err := Enumerate("example.com", EnumOptions{Method: tc.method, Wordlist: tc.wordlist})
+		if err == nil {
+			t.Errorf("expected error for method %q with wordlist %q, got nil", tc.method, tc.wordlist)
+		}
+	}
+}
+
+func TestEnumCrtsh_DefaultMethod(t *testing.T) {
+	// Verify that "crtsh" is the default method by checking no unknown-method error.
+	// We can't make real network calls in unit tests, but we can confirm the routing.
+	// This test exercises the validation path only; skip if no network is expected.
+	result, err := Enumerate("this-domain-does-not-exist-xyzzy123.invalid", EnumOptions{})
+	// We accept either a network error or a "no subdomains found" result.
+	if err != nil {
+		if strings.Contains(err.Error(), "unknown method") {
+			t.Errorf("default method should be crtsh, not unknown: %v", err)
+		}
+		// Any other error (network, DNS, etc.) is acceptable in this unit test.
+		return
+	}
+	if result == "" {
+		t.Error("expected non-empty result")
+	}
+}


### PR DESCRIPTION
Add subdomain_enum tool supporting three enumeration methods: crtsh (certificate transparency logs), gobuster (DNS brute-force), and ffuf (HTTP brute-force).

Closes #12

Generated with [Claude Code](https://claude.ai/code)