### PR TITLE
feat: add port_service_banner tool for TCP banner grabbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,20 @@ Analyze TLS/SSL certificates and configuration for a host: check certificate exp
 
 **Example prompt**: "Inspect the TLS configuration of example.com"
 
+### `port_service_banner`
+
+Connect to open TCP ports and grab service banners to identify running software and versions. This is faster than `nmap -sV` for targeted banner collection on already-identified open ports.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `target`  | Yes      | Target IP address or hostname |
+| `ports`   | Yes      | Ports to probe: single port (`22`), comma-separated (`22,80,443`), or range (`8000-8010`). Maximum 256 ports per call. |
+| `timeout` | No       | Connection and read timeout in seconds (default: `5`) |
+
+**Example prompts**:
+- "Grab service banners from ports 22, 80, and 443 on 192.168.1.1"
+- "Identify what's running on ports 8000-8010 on 10.0.0.1"
+
 ### `subdomain_enum`
 
 Enumerate subdomains for a domain using certificate transparency logs or wordlist brute-forcing.

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -10,6 +11,7 @@ import (
 	"github.com/mycroft/sec-skills-mcp/tools/dns"
 	http_probe "github.com/mycroft/sec-skills-mcp/tools/http_probe"
 	"github.com/mycroft/sec-skills-mcp/tools/nmap"
+	port_service_banner "github.com/mycroft/sec-skills-mcp/tools/port_service_banner"
 	ssl_inspect "github.com/mycroft/sec-skills-mcp/tools/ssl_inspect"
 	subdomain_enum "github.com/mycroft/sec-skills-mcp/tools/subdomain_enum"
 	"github.com/mycroft/sec-skills-mcp/tools/whois"
@@ -74,6 +76,21 @@ func New() *server.MCPServer {
 			mcp.Description("When true, skip TLS certificate verification (useful for self-signed certs). Defaults to false."),
 		),
 	), httpProbeHandler)
+
+	s.AddTool(mcp.NewTool("port_service_banner",
+		mcp.WithDescription("Connect to open TCP ports and grab service banners to identify running software and versions. Faster than nmap -sV for targeted banner collection. Only use against hosts you are authorized to test."),
+		mcp.WithString("target",
+			mcp.Required(),
+			mcp.Description("Target IP address or hostname"),
+		),
+		mcp.WithString("ports",
+			mcp.Required(),
+			mcp.Description("Ports to probe: single port ('22'), comma-separated ('22,80,443'), or range ('8000-8010'). Maximum 256 ports per call."),
+		),
+		mcp.WithString("timeout",
+			mcp.Description("Connection and read timeout in seconds (default: 5)"),
+		),
+	), portServiceBannerHandler)
 
 	s.AddTool(mcp.NewTool("subdomain_enum",
 		mcp.WithDescription("Enumerate subdomains for a domain using certificate transparency logs (crt.sh) or wordlist brute-forcing (gobuster/ffuf). Only use against domains you are authorized to test."),
@@ -186,6 +203,31 @@ func httpProbeHandler(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 	result, err := http_probe.Probe(target, opts)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("HTTP probe failed: %v", err)), nil
+	}
+	return mcp.NewToolResultText(result), nil
+}
+
+func portServiceBannerHandler(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	target, ok := req.Params.Arguments["target"].(string)
+	if !ok || target == "" {
+		return mcp.NewToolResultError("target parameter is required"), nil
+	}
+
+	ports, ok := req.Params.Arguments["ports"].(string)
+	if !ok || ports == "" {
+		return mcp.NewToolResultError("ports parameter is required"), nil
+	}
+
+	var timeoutSecs int
+	if t, ok := req.Params.Arguments["timeout"].(string); ok && t != "" {
+		if n, err := strconv.Atoi(t); err == nil && n > 0 {
+			timeoutSecs = n
+		}
+	}
+
+	result, err := port_service_banner.GrabBanners(target, ports, timeoutSecs)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("banner grab failed: %v", err)), nil
 	}
 	return mcp.NewToolResultText(result), nil
 }

--- a/tools/port_service_banner/port_service_banner.go
+++ b/tools/port_service_banner/port_service_banner.go
@@ -1,0 +1,191 @@
+package port_service_banner
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// validTarget allows hostnames and IP addresses.
+var validTarget = regexp.MustCompile(`^[a-zA-Z0-9._:\[\]-]+$`)
+
+// validPorts allows port numbers, ranges, and comma-separated lists.
+var validPorts = regexp.MustCompile(`^[0-9,\-]+$`)
+
+// defaultTimeout is the default connection and read timeout.
+const defaultTimeout = 5 * time.Second
+
+// maxBannerBytes is the maximum number of bytes to read per banner.
+const maxBannerBytes = 4096
+
+// BannerResult holds the result for a single port.
+type BannerResult struct {
+	Port   int
+	Banner string
+	Err    error
+}
+
+// GrabBanners connects to each port on target and reads the service banner.
+// ports is a comma-separated list of port numbers or ranges (e.g. "22,80,8080" or "8000-8010").
+// timeoutSecs controls the TCP connect and read deadline; 0 uses the default of 5 seconds.
+func GrabBanners(target, ports string, timeoutSecs int) (string, error) {
+	if target == "" {
+		return "", fmt.Errorf("target must not be empty")
+	}
+	if !validTarget.MatchString(target) {
+		return "", fmt.Errorf("invalid target %q: only alphanumeric characters, dots, hyphens, colons, and brackets are allowed", target)
+	}
+	if ports == "" {
+		return "", fmt.Errorf("ports must not be empty")
+	}
+	if !validPorts.MatchString(ports) {
+		return "", fmt.Errorf("invalid ports %q: only digits, commas, and hyphens are allowed", ports)
+	}
+
+	timeout := defaultTimeout
+	if timeoutSecs > 0 {
+		timeout = time.Duration(timeoutSecs) * time.Second
+	}
+
+	portList, err := parsePorts(ports)
+	if err != nil {
+		return "", err
+	}
+	if len(portList) == 0 {
+		return "", fmt.Errorf("no valid ports specified")
+	}
+	if len(portList) > 256 {
+		return "", fmt.Errorf("too many ports: maximum 256 ports per call")
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Banner Grab: %s\n\n", target)
+
+	for _, port := range portList {
+		result := grabBanner(target, port, timeout)
+		fmt.Fprintf(&sb, "Port %d/tcp\n", result.Port)
+		if result.Err != nil {
+			fmt.Fprintf(&sb, "  Status: closed/filtered (%v)\n", result.Err)
+		} else if result.Banner == "" {
+			fmt.Fprintf(&sb, "  Status: open (no banner received)\n")
+		} else {
+			fmt.Fprintf(&sb, "  Status: open\n")
+			fmt.Fprintf(&sb, "  Banner: %s\n", result.Banner)
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String(), nil
+}
+
+// grabBanner connects to target:port, reads the initial banner, and returns the result.
+// For ports that don't send a banner spontaneously a generic probe is sent.
+func grabBanner(target string, port int, timeout time.Duration) BannerResult {
+	addr := net.JoinHostPort(target, strconv.Itoa(port))
+
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return BannerResult{Port: port, Err: err}
+	}
+	defer conn.Close()
+
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return BannerResult{Port: port, Err: fmt.Errorf("set deadline: %w", err)}
+	}
+
+	// Read initial banner.
+	buf := make([]byte, maxBannerBytes)
+	n, err := conn.Read(buf)
+	if err != nil && err != io.EOF {
+		// Many services don't send a banner first — send a generic probe and try again.
+		conn.SetDeadline(time.Now().Add(timeout)) //nolint:errcheck
+		_, writeErr := fmt.Fprintf(conn, "\r\n")
+		if writeErr != nil {
+			// Port is open but unresponsive — that's still interesting.
+			return BannerResult{Port: port, Banner: ""}
+		}
+		n, err = conn.Read(buf)
+		if err != nil && err != io.EOF {
+			return BannerResult{Port: port, Banner: ""}
+		}
+	}
+
+	banner := sanitizeBanner(buf[:n])
+	return BannerResult{Port: port, Banner: banner}
+}
+
+// sanitizeBanner cleans up raw banner bytes into a single, printable line.
+// Non-printable characters are replaced with dots; leading/trailing whitespace
+// is trimmed. A multi-line banner is collapsed to its first non-empty line.
+func sanitizeBanner(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	// Replace non-printable characters (except common whitespace) with dots.
+	cleaned := strings.Map(func(r rune) rune {
+		if r == '\r' || r == '\n' {
+			return '\n'
+		}
+		if unicode.IsPrint(r) || r == '\t' {
+			return r
+		}
+		return '.'
+	}, string(raw))
+
+	// Return the first non-empty line.
+	for _, line := range strings.Split(cleaned, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// parsePorts parses a port specification string into a sorted list of port numbers.
+// Supports individual ports ("80"), ranges ("8000-8010"), and comma-separated lists.
+func parsePorts(spec string) ([]int, error) {
+	seen := make(map[int]bool)
+	var ports []int
+
+	for _, part := range strings.Split(spec, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if strings.Contains(part, "-") {
+			bounds := strings.SplitN(part, "-", 2)
+			if len(bounds) != 2 {
+				return nil, fmt.Errorf("invalid port range %q", part)
+			}
+			lo, err1 := strconv.Atoi(bounds[0])
+			hi, err2 := strconv.Atoi(bounds[1])
+			if err1 != nil || err2 != nil || lo < 1 || hi > 65535 || lo > hi {
+				return nil, fmt.Errorf("invalid port range %q: ports must be between 1 and 65535 with low <= high", part)
+			}
+			for p := lo; p <= hi; p++ {
+				if !seen[p] {
+					seen[p] = true
+					ports = append(ports, p)
+				}
+			}
+		} else {
+			p, err := strconv.Atoi(part)
+			if err != nil || p < 1 || p > 65535 {
+				return nil, fmt.Errorf("invalid port %q: must be a number between 1 and 65535", part)
+			}
+			if !seen[p] {
+				seen[p] = true
+				ports = append(ports, p)
+			}
+		}
+	}
+
+	return ports, nil
+}

--- a/tools/port_service_banner/port_service_banner_test.go
+++ b/tools/port_service_banner/port_service_banner_test.go
@@ -1,0 +1,188 @@
+package port_service_banner
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+// --- parsePorts ---
+
+func TestParsePorts_Single(t *testing.T) {
+	ports, err := parsePorts("80")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ports) != 1 || ports[0] != 80 {
+		t.Errorf("expected [80], got %v", ports)
+	}
+}
+
+func TestParsePorts_Multiple(t *testing.T) {
+	ports, err := parsePorts("80,443,8080")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ports) != 3 {
+		t.Errorf("expected 3 ports, got %d", len(ports))
+	}
+}
+
+func TestParsePorts_Range(t *testing.T) {
+	ports, err := parsePorts("8000-8003")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ports) != 4 {
+		t.Errorf("expected 4 ports, got %d: %v", len(ports), ports)
+	}
+}
+
+func TestParsePorts_InvalidRange(t *testing.T) {
+	cases := []string{
+		"8080-80",      // low > high
+		"0-100",        // port 0 invalid
+		"100-70000",    // port > 65535
+		"abc-def",      // non-numeric
+	}
+	for _, tc := range cases {
+		_, err := parsePorts(tc)
+		if err == nil {
+			t.Errorf("expected error for ports %q, got nil", tc)
+		}
+	}
+}
+
+func TestParsePorts_InvalidPort(t *testing.T) {
+	cases := []string{"0", "65536", "abc", "-1"}
+	for _, tc := range cases {
+		_, err := parsePorts(tc)
+		if err == nil {
+			t.Errorf("expected error for port %q, got nil", tc)
+		}
+	}
+}
+
+func TestParsePorts_Deduplication(t *testing.T) {
+	ports, err := parsePorts("80,80,80")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ports) != 1 {
+		t.Errorf("expected 1 unique port, got %d", len(ports))
+	}
+}
+
+// --- sanitizeBanner ---
+
+func TestSanitizeBanner_Empty(t *testing.T) {
+	if sanitizeBanner([]byte{}) != "" {
+		t.Error("expected empty string for empty input")
+	}
+}
+
+func TestSanitizeBanner_SimpleText(t *testing.T) {
+	banner := sanitizeBanner([]byte("SSH-2.0-OpenSSH_8.9\r\n"))
+	if banner != "SSH-2.0-OpenSSH_8.9" {
+		t.Errorf("unexpected banner: %q", banner)
+	}
+}
+
+func TestSanitizeBanner_MultiLine(t *testing.T) {
+	banner := sanitizeBanner([]byte("220 smtp.example.com ESMTP\r\n250 more stuff\r\n"))
+	if banner != "220 smtp.example.com ESMTP" {
+		t.Errorf("unexpected banner: %q", banner)
+	}
+}
+
+func TestSanitizeBanner_NonPrintable(t *testing.T) {
+	banner := sanitizeBanner([]byte("hello\x01\x02world"))
+	if !strings.Contains(banner, "hello") || !strings.Contains(banner, "world") {
+		t.Errorf("unexpected banner: %q", banner)
+	}
+}
+
+// --- GrabBanners input validation ---
+
+func TestGrabBanners_EmptyTarget(t *testing.T) {
+	_, err := GrabBanners("", "80", 0)
+	if err == nil {
+		t.Fatal("expected error for empty target")
+	}
+}
+
+func TestGrabBanners_EmptyPorts(t *testing.T) {
+	_, err := GrabBanners("localhost", "", 0)
+	if err == nil {
+		t.Fatal("expected error for empty ports")
+	}
+}
+
+func TestGrabBanners_InvalidTarget(t *testing.T) {
+	cases := []string{
+		"host; rm -rf /",
+		"$(whoami)",
+		"host && cat /etc/passwd",
+	}
+	for _, tc := range cases {
+		_, err := GrabBanners(tc, "80", 0)
+		if err == nil {
+			t.Errorf("expected error for target %q, got nil", tc)
+		}
+	}
+}
+
+func TestGrabBanners_InvalidPorts(t *testing.T) {
+	cases := []string{
+		"80; rm -rf /",
+		"$(whoami)",
+		"80 443",
+	}
+	for _, tc := range cases {
+		_, err := GrabBanners("localhost", tc, 0)
+		if err == nil {
+			t.Errorf("expected error for ports %q, got nil", tc)
+		}
+	}
+}
+
+// --- Integration test using a local listener ---
+
+func TestGrabBanners_Integration(t *testing.T) {
+	// Start a local TCP server that sends a banner.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+
+	portStr := strings.TrimPrefix(ln.Addr().String(), "127.0.0.1:")
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		conn.Write([]byte("TEST-BANNER-1.0\r\n")) //nolint:errcheck
+	}()
+
+	out, err := GrabBanners("127.0.0.1", portStr, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "TEST-BANNER-1.0") {
+		t.Errorf("expected banner in output, got:\n%s", out)
+	}
+}
+
+func TestGrabBanners_ClosedPort(t *testing.T) {
+	// Use a port that is very unlikely to be open.
+	out, err := GrabBanners("127.0.0.1", "19999", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "closed/filtered") {
+		t.Errorf("expected closed/filtered in output, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
Implements the `port_service_banner` MCP tool that connects to open TCP ports and reads service banners to identify running software and versions. Faster than nmap -sV for targeted reconnaissance on already-identified open ports.

Closes #14

Generated with [Claude Code](https://claude.ai/code)