### PR TITLE
feat: implement jwt_analyzer skill

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mycroft/sec-skills-mcp/tools/dns"
 	http_probe "github.com/mycroft/sec-skills-mcp/tools/http_probe"
+	jwt_analyzer "github.com/mycroft/sec-skills-mcp/tools/jwt_analyzer"
 	"github.com/mycroft/sec-skills-mcp/tools/nmap"
 	port_service_banner "github.com/mycroft/sec-skills-mcp/tools/port_service_banner"
 	ssl_inspect "github.com/mycroft/sec-skills-mcp/tools/ssl_inspect"
@@ -92,6 +93,14 @@ func New() *server.MCPServer {
 		),
 	), portServiceBannerHandler)
 
+	s.AddTool(mcp.NewTool("jwt_analyzer",
+		mcp.WithDescription("Decode and analyze a JWT (JSON Web Token): display header, payload claims, and signature; detect vulnerabilities such as the 'none' algorithm, missing expiration, and weak HMAC secrets."),
+		mcp.WithString("token",
+			mcp.Required(),
+			mcp.Description("The JWT token string to analyze (e.g. 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...')"),
+		),
+	), jwtAnalyzerHandler)
+
 	s.AddTool(mcp.NewTool("subdomain_enum",
 		mcp.WithDescription("Enumerate subdomains for a domain using certificate transparency logs (crt.sh) or wordlist brute-forcing (gobuster/ffuf). Only use against domains you are authorized to test."),
 		mcp.WithString("domain",
@@ -107,6 +116,19 @@ func New() *server.MCPServer {
 	), subdomainEnumHandler)
 
 	return s
+}
+
+func jwtAnalyzerHandler(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	token, ok := req.Params.Arguments["token"].(string)
+	if !ok || token == "" {
+		return mcp.NewToolResultError("token parameter is required"), nil
+	}
+
+	result, err := jwt_analyzer.Analyze(token)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("JWT analysis failed: %v", err)), nil
+	}
+	return mcp.NewToolResultText(result), nil
 }
 
 func sslInspectHandler(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/tools/jwt_analyzer/jwt_analyzer.go
+++ b/tools/jwt_analyzer/jwt_analyzer.go
@@ -1,0 +1,296 @@
+package jwt_analyzer
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"strings"
+	"time"
+)
+
+// weakSecrets is a list of commonly used weak JWT secrets to test against.
+var weakSecrets = []string{
+	"secret",
+	"password",
+	"123456",
+	"key",
+	"jwt",
+	"token",
+	"supersecret",
+	"changeme",
+	"default",
+	"admin",
+	"test",
+	"qwerty",
+	"letmein",
+	"pass",
+	"1234",
+	"abc123",
+}
+
+// header represents the decoded JWT header fields.
+type header struct {
+	Algorithm string `json:"alg"`
+	Type      string `json:"typ"`
+	KeyID     string `json:"kid,omitempty"`
+	raw       map[string]interface{}
+}
+
+// payload represents the decoded JWT payload claims.
+type payload struct {
+	Issuer     string      `json:"iss,omitempty"`
+	Subject    string      `json:"sub,omitempty"`
+	Audience   interface{} `json:"aud,omitempty"`
+	Expiration *int64      `json:"exp,omitempty"`
+	NotBefore  *int64      `json:"nbf,omitempty"`
+	IssuedAt   *int64      `json:"iat,omitempty"`
+	JWTID      string      `json:"jti,omitempty"`
+	raw        map[string]interface{}
+}
+
+// decodeSegment decodes a base64url-encoded JWT segment (no padding required).
+func decodeSegment(seg string) ([]byte, error) {
+	// Add padding if needed
+	switch len(seg) % 4 {
+	case 2:
+		seg += "=="
+	case 3:
+		seg += "="
+	}
+	return base64.URLEncoding.DecodeString(seg)
+}
+
+// Analyze decodes and analyzes a JWT token, checking for vulnerabilities.
+func Analyze(token string) (string, error) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return "", fmt.Errorf("token must not be empty")
+	}
+
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid JWT format: expected 3 parts separated by '.', got %d", len(parts))
+	}
+
+	headerBytes, err := decodeSegment(parts[0])
+	if err != nil {
+		return "", fmt.Errorf("failed to decode JWT header: %w", err)
+	}
+
+	payloadBytes, err := decodeSegment(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("failed to decode JWT payload: %w", err)
+	}
+
+	var h header
+	if err := json.Unmarshal(headerBytes, &h); err != nil {
+		return "", fmt.Errorf("failed to parse JWT header: %w", err)
+	}
+	if err := json.Unmarshal(headerBytes, &h.raw); err != nil {
+		return "", fmt.Errorf("failed to parse JWT header: %w", err)
+	}
+
+	var p payload
+	if err := json.Unmarshal(payloadBytes, &p); err != nil {
+		return "", fmt.Errorf("failed to parse JWT payload: %w", err)
+	}
+	if err := json.Unmarshal(payloadBytes, &p.raw); err != nil {
+		return "", fmt.Errorf("failed to parse JWT payload: %w", err)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("=== JWT Analysis ===\n\n")
+
+	// Header section
+	sb.WriteString("--- Header ---\n")
+	fmt.Fprintf(&sb, "Algorithm: %s\n", h.Algorithm)
+	fmt.Fprintf(&sb, "Type:      %s\n", h.Type)
+	if h.KeyID != "" {
+		fmt.Fprintf(&sb, "Key ID:    %s\n", h.KeyID)
+	}
+	// Print any extra header fields
+	for k, v := range h.raw {
+		if k == "alg" || k == "typ" || k == "kid" {
+			continue
+		}
+		fmt.Fprintf(&sb, "%-10s %v\n", k+":", v)
+	}
+
+	// Payload section
+	sb.WriteString("\n--- Payload / Claims ---\n")
+	if p.Issuer != "" {
+		fmt.Fprintf(&sb, "Issuer (iss):      %s\n", p.Issuer)
+	}
+	if p.Subject != "" {
+		fmt.Fprintf(&sb, "Subject (sub):     %s\n", p.Subject)
+	}
+	if p.Audience != nil {
+		switch aud := p.Audience.(type) {
+		case string:
+			fmt.Fprintf(&sb, "Audience (aud):    %s\n", aud)
+		case []interface{}:
+			audStrs := make([]string, 0, len(aud))
+			for _, a := range aud {
+				audStrs = append(audStrs, fmt.Sprintf("%v", a))
+			}
+			fmt.Fprintf(&sb, "Audience (aud):    %s\n", strings.Join(audStrs, ", "))
+		}
+	}
+	if p.JWTID != "" {
+		fmt.Fprintf(&sb, "JWT ID (jti):      %s\n", p.JWTID)
+	}
+
+	now := time.Now()
+
+	if p.IssuedAt != nil {
+		iat := time.Unix(*p.IssuedAt, 0)
+		fmt.Fprintf(&sb, "Issued At (iat):   %s\n", iat.UTC().Format(time.RFC3339))
+	}
+	if p.NotBefore != nil {
+		nbf := time.Unix(*p.NotBefore, 0)
+		if now.Before(nbf) {
+			fmt.Fprintf(&sb, "Not Before (nbf):  %s  [NOT YET VALID]\n", nbf.UTC().Format(time.RFC3339))
+		} else {
+			fmt.Fprintf(&sb, "Not Before (nbf):  %s\n", nbf.UTC().Format(time.RFC3339))
+		}
+	}
+	if p.Expiration != nil {
+		exp := time.Unix(*p.Expiration, 0)
+		if now.After(exp) {
+			fmt.Fprintf(&sb, "Expiration (exp):  %s  [EXPIRED]\n", exp.UTC().Format(time.RFC3339))
+		} else {
+			remaining := time.Until(exp)
+			fmt.Fprintf(&sb, "Expiration (exp):  %s  (expires in %s)\n", exp.UTC().Format(time.RFC3339), formatDuration(remaining))
+		}
+	} else {
+		fmt.Fprintf(&sb, "Expiration (exp):  NOT SET\n")
+	}
+
+	// Extra claims
+	knownClaims := map[string]bool{
+		"iss": true, "sub": true, "aud": true,
+		"exp": true, "nbf": true, "iat": true, "jti": true,
+	}
+	var extraClaims []string
+	for k := range p.raw {
+		if !knownClaims[k] {
+			extraClaims = append(extraClaims, k)
+		}
+	}
+	if len(extraClaims) > 0 {
+		sb.WriteString("\nCustom Claims:\n")
+		for _, k := range extraClaims {
+			fmt.Fprintf(&sb, "  %-18s %v\n", k+":", p.raw[k])
+		}
+	}
+
+	// Signature section
+	sb.WriteString("\n--- Signature ---\n")
+	sigBytes, err := decodeSegment(parts[2])
+	if err != nil {
+		sb.WriteString("Signature: (could not decode)\n")
+	} else if len(sigBytes) == 0 {
+		sb.WriteString("Signature: EMPTY (unsigned token)\n")
+	} else {
+		fmt.Fprintf(&sb, "Signature: %d bytes (base64url encoded)\n", len(sigBytes))
+	}
+
+	// Vulnerability checks
+	sb.WriteString("\n--- Vulnerability Analysis ---\n")
+	var vulns []string
+
+	// Check: none algorithm
+	alg := strings.ToLower(h.Algorithm)
+	if alg == "none" || alg == "" {
+		vulns = append(vulns, "CRITICAL: Algorithm is 'none' — token is unsigned and trivially forgeable")
+	}
+
+	// Check: no expiration
+	if p.Expiration == nil {
+		vulns = append(vulns, "WARNING: No expiration (exp) claim — token never expires and cannot be invalidated by time")
+	} else if now.After(time.Unix(*p.Expiration, 0)) {
+		vulns = append(vulns, "WARNING: Token is EXPIRED")
+	}
+
+	// Check: not-before in the future
+	if p.NotBefore != nil && now.Before(time.Unix(*p.NotBefore, 0)) {
+		vulns = append(vulns, "INFO: Token is not yet valid (nbf is in the future)")
+	}
+
+	// Check: weak secrets for HMAC algorithms
+	weakSecret := checkWeakSecret(parts[0]+"."+parts[1], parts[2], h.Algorithm)
+	if weakSecret != "" {
+		vulns = append(vulns, fmt.Sprintf("CRITICAL: Weak signing secret detected: %q — token can be forged", weakSecret))
+	}
+
+	// Check: algorithm confusion (RS/ES algorithm with short key)
+	if strings.HasPrefix(alg, "hs") && len(parts[2]) < 20 {
+		vulns = append(vulns, "WARNING: HMAC signature appears very short — possible weak key")
+	}
+
+	if len(vulns) == 0 {
+		sb.WriteString("No obvious vulnerabilities detected.\n")
+	} else {
+		for _, v := range vulns {
+			fmt.Fprintf(&sb, "  [!] %s\n", v)
+		}
+	}
+
+	return sb.String(), nil
+}
+
+// checkWeakSecret tries to verify the JWT signature against a list of common
+// weak secrets. Returns the matching secret if found, or "" if none matched.
+func checkWeakSecret(signingInput, signatureB64, algorithm string) string {
+	alg := strings.ToUpper(algorithm)
+
+	var newHashFunc func() hash.Hash
+	switch alg {
+	case "HS256":
+		newHashFunc = sha256.New
+	case "HS384":
+		newHashFunc = sha512.New384
+	case "HS512":
+		newHashFunc = sha512.New
+	default:
+		// Only HMAC-based algorithms can be checked this way
+		return ""
+	}
+
+	sigBytes, err := decodeSegment(signatureB64)
+	if err != nil {
+		return ""
+	}
+
+	for _, secret := range weakSecrets {
+		mac := hmac.New(newHashFunc, []byte(secret))
+		mac.Write([]byte(signingInput))
+		expected := mac.Sum(nil)
+		if hmac.Equal(expected, sigBytes) {
+			return secret
+		}
+	}
+	return ""
+}
+
+// formatDuration formats a duration as a human-readable string.
+func formatDuration(d time.Duration) string {
+	if d < 0 {
+		return "expired"
+	}
+	days := int(d.Hours()) / 24
+	hours := int(d.Hours()) % 24
+	minutes := int(d.Minutes()) % 60
+
+	if days > 0 {
+		return fmt.Sprintf("%dd %dh %dm", days, hours, minutes)
+	}
+	if hours > 0 {
+		return fmt.Sprintf("%dh %dm", hours, minutes)
+	}
+	return fmt.Sprintf("%dm", minutes)
+}

--- a/tools/jwt_analyzer/jwt_analyzer_test.go
+++ b/tools/jwt_analyzer/jwt_analyzer_test.go
@@ -1,0 +1,199 @@
+package jwt_analyzer
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildHS256Token creates a minimal HS256-signed JWT for testing purposes.
+func buildHS256Token(payloadMap map[string]interface{}, secret string) string {
+	headerJSON, _ := json.Marshal(map[string]string{"alg": "HS256", "typ": "JWT"})
+	payloadJSON, _ := json.Marshal(payloadMap)
+
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	signingInput := headerB64 + "." + payloadB64
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(signingInput))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	return signingInput + "." + sig
+}
+
+func TestAnalyze_EmptyToken(t *testing.T) {
+	_, err := Analyze("")
+	if err == nil {
+		t.Fatal("expected error for empty token, got nil")
+	}
+}
+
+func TestAnalyze_InvalidFormat(t *testing.T) {
+	cases := []struct {
+		name  string
+		token string
+	}{
+		{"no dots", "notavalidtoken"},
+		{"one dot", "header.payload"},
+		{"too many parts", "a.b.c.d"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Analyze(tc.token)
+			if err == nil {
+				t.Errorf("expected error for token %q, got nil", tc.token)
+			}
+		})
+	}
+}
+
+func TestAnalyze_NoneAlgorithm(t *testing.T) {
+	// JWT with alg=none: header={"alg":"none","typ":"JWT"}, payload={"sub":"test"}, no signature
+	// eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJ0ZXN0In0.
+	token := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJ0ZXN0In0."
+	result, err := Analyze(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "none") {
+		t.Errorf("expected 'none' in result, got:\n%s", result)
+	}
+	if !strings.Contains(result, "CRITICAL") {
+		t.Errorf("expected CRITICAL vulnerability for none algorithm, got:\n%s", result)
+	}
+}
+
+func TestAnalyze_NoExpiration(t *testing.T) {
+	token := buildHS256Token(map[string]interface{}{"sub": "user"}, "strongsecret")
+	result, err := Analyze(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "Expiration (exp):  NOT SET") {
+		t.Errorf("expected no-expiration notice, got:\n%s", result)
+	}
+	if !strings.Contains(result, "WARNING: No expiration") {
+		t.Errorf("expected WARNING for missing exp, got:\n%s", result)
+	}
+}
+
+func TestAnalyze_WeakSecret(t *testing.T) {
+	token := buildHS256Token(map[string]interface{}{"sub": "user"}, "secret")
+	result, err := Analyze(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "Weak signing secret") {
+		t.Errorf("expected weak secret detection, got:\n%s", result)
+	}
+	if !strings.Contains(result, `"secret"`) {
+		t.Errorf("expected detected secret to be 'secret', got:\n%s", result)
+	}
+}
+
+func TestAnalyze_StrongSecret_NoWeakDetection(t *testing.T) {
+	token := buildHS256Token(map[string]interface{}{"sub": "user"}, "this-is-a-very-strong-random-secret-xyz")
+	result, err := Analyze(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(result, "Weak signing secret") {
+		t.Errorf("should not detect weak secret for strong key, got:\n%s", result)
+	}
+}
+
+func TestAnalyze_ValidToken_Structure(t *testing.T) {
+	exp := time.Now().Add(time.Hour).Unix()
+	token := buildHS256Token(map[string]interface{}{
+		"sub": "1234567890",
+		"iss": "test-issuer",
+		"exp": exp,
+	}, "strongsecret")
+
+	result, err := Analyze(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, section := range []string{"Header", "Payload", "Signature", "Vulnerability"} {
+		if !strings.Contains(result, section) {
+			t.Errorf("expected section %q in result, got:\n%s", section, result)
+		}
+	}
+	if !strings.Contains(result, "Issuer (iss):") {
+		t.Errorf("expected issuer in result, got:\n%s", result)
+	}
+}
+
+func TestAnalyze_ExpiredToken(t *testing.T) {
+	past := time.Now().Add(-time.Hour).Unix()
+	token := buildHS256Token(map[string]interface{}{
+		"sub": "user",
+		"exp": past,
+	}, "strongsecret")
+
+	result, err := Analyze(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "EXPIRED") {
+		t.Errorf("expected EXPIRED in result, got:\n%s", result)
+	}
+	if !strings.Contains(result, "WARNING: Token is EXPIRED") {
+		t.Errorf("expected expired vulnerability warning, got:\n%s", result)
+	}
+}
+
+func TestAnalyze_NotYetValid(t *testing.T) {
+	future := time.Now().Add(time.Hour).Unix()
+	token := buildHS256Token(map[string]interface{}{
+		"sub": "user",
+		"nbf": future,
+	}, "strongsecret")
+
+	result, err := Analyze(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "NOT YET VALID") {
+		t.Errorf("expected NOT YET VALID notice, got:\n%s", result)
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{0, "0m"},
+		{30 * time.Minute, "30m"},
+		{90 * time.Minute, "1h 30m"},
+		{25*time.Hour + 30*time.Minute, "1d 1h 30m"},
+	}
+	for _, tc := range cases {
+		got := formatDuration(tc.d)
+		if got != tc.want {
+			t.Errorf("formatDuration(%v) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+func TestDecodeSegment_Padding(t *testing.T) {
+	cases := []struct {
+		input string
+		valid bool
+	}{
+		{"eyJhbGciOiJub25lIn0", true},
+		{"eyJhbGciOiJIUzI1NiJ9", true},
+	}
+	for _, tc := range cases {
+		_, err := decodeSegment(tc.input)
+		if tc.valid && err != nil {
+			t.Errorf("decodeSegment(%q) unexpected error: %v", tc.input, err)
+		}
+	}
+}


### PR DESCRIPTION
Implements the `jwt_analyzer` MCP tool to decode and analyze JWT tokens, including vulnerability detection for none algorithm, weak secrets, missing expiration, and expired tokens.

Closes #16

Generated with [Claude Code](https://claude.ai/code)